### PR TITLE
Add skip-path to checkov

### DIFF
--- a/.github/checkov-config.yml
+++ b/.github/checkov-config.yml
@@ -4,4 +4,6 @@ framework:
   - terraform
 output: cli,sarif
 quiet: true     # Display only failed checks
+skip-path:
+  - /examples     # Skip scanning the examples directory
 soft-fail: true # Do not return an error code if there are failed checks


### PR DESCRIPTION
Add `/examples` to skip-path so checkov won't scan non-production code samples.